### PR TITLE
Proof of Concept solution to the `internal.takeThroughDrain` issues

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,12 +8,12 @@ lazy val contributors = Seq(
   , "mrauilm" -> "Milan Raulim"
 )
 
-val fs2Version = "2.0.0"
+val fs2Version = "2.0.1"
 
 lazy val commonSettings = Seq(
   organization := "com.spinoco",
-  scalaVersion := "2.12.4",
-  crossScalaVersions := Seq("2.11.11", "2.12.4"),
+  scalaVersion := "2.12.10",
+  crossScalaVersions := Seq("2.11.12", "2.12.10"),
   scalacOptions ++= Seq(
     "-feature",
     "-deprecation",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.6
+sbt.version=1.3.3

--- a/src/main/scala/spinoco/fs2/mail/internal/internal.scala
+++ b/src/main/scala/spinoco/fs2/mail/internal/internal.scala
@@ -18,7 +18,7 @@ package object internal {
     * Once downstream finishes this synchronous queue is read until exhaustion marked by [[None]].
     */
   def takeThroughDrain[F[_] : Concurrent, A](predicate: A => Boolean): Pipe[F, A, A] = { source =>
-    Stream.eval(fs2.concurrent.Queue.synchronous[F, Option[Either[Throwable, A]]]).flatMap{ feedQueue =>
+    Stream.eval(fs2.concurrent.Queue.unbounded[F, Option[Either[Throwable, A]]]).flatMap{ feedQueue =>
 
       // dequeue and propagate errors to downstream
       def dequeue:Stream[F, A] = {

--- a/src/test/scala/spinoco/fs2/mail/encoding/quotedPrintableSpec.scala
+++ b/src/test/scala/spinoco/fs2/mail/encoding/quotedPrintableSpec.scala
@@ -53,7 +53,7 @@ object quotedPrintableSpec extends Properties("quotedPrintable") {
           |un moyen, et te trompant ainsi sur la route =C3=A0 suivre les voil=C3=A0 bi=
           |ent=C3=B4t qui te d=C3=A9gradent, car si leur musique est vulgaire ils te f=
           |abriquent pour te la vendre une =C3=A2me vulgaire."""
-          .stripMargin.lines.toSeq
+          .stripMargin.linesIterator.toSeq
       , raw = Seq(
         """J'interdis aux marchands de vanter trop leur marchandises. Car ils se font vite pédagogues et t'enseignent comme but ce qui n'est par essence qu'un moyen, et te trompant ainsi sur la route à suivre les voilà bientôt qui te dégradent, car si leur musique est vulgaire ils te fabriquent pour te la vendre une âme vulgaire."""
       )
@@ -86,7 +86,7 @@ object quotedPrintableSpec extends Properties("quotedPrintable") {
           |in
           |wenig aufschieben, denn auch uns f=C3=BCrchten, wie ihr seht, einige Tiere,
           |welche also wohl noch ungl=C3=BCcklicher sein m=C3=BCssen als wir.""""
-          .stripMargin.lines.toSeq
+          .stripMargin.linesIterator.toSeq
       , raw = Seq(
         "Die Hasen und die Frösche"
         , ""

--- a/src/test/scala/spinoco/fs2/mail/imap/IMAPClientFetchSpec.scala
+++ b/src/test/scala/spinoco/fs2/mail/imap/IMAPClientFetchSpec.scala
@@ -106,7 +106,7 @@ object IMAPClientFetchSpec extends Properties("IMAPClient.Fetch"){
       |* 0 EXPUNGE
       |3 OK Success
       |
-      |""".stripMargin.lines.mkString("\r\n")
+      |""".stripMargin.linesIterator.mkString("\r\n")
 
   val multipleHeadersResponse =
     """* 4249 FETCH (BODY[HEADER] {4774}
@@ -277,7 +277,7 @@ object IMAPClientFetchSpec extends Properties("IMAPClient.Fetch"){
       |)
       |4 OK Success
       |
-      |""".stripMargin.lines.mkString("\r\n")
+      |""".stripMargin.linesIterator.mkString("\r\n")
 
 
   def parseFetchResponse(resp: String, chunkSz: Int): Vector[Either[String, Long]] = {
@@ -420,7 +420,7 @@ object IMAPClientFetchSpec extends Properties("IMAPClient.Fetch"){
       |AAAASUVORK5CYII=)
       |10 OK Success
       |
-      |""".stripMargin.stripMargin.lines.mkString("\r\n")
+      |""".stripMargin.stripMargin.linesIterator.mkString("\r\n")
 
   val fetchBodyBytes = ByteVector.fromBase64(
     """iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAPFBMVEX///+1tbWwsLCtra3////5
@@ -470,14 +470,14 @@ object IMAPClientFetchSpec extends Properties("IMAPClient.Fetch"){
       |Please click on the link below to create your account https://accounts.restcomm.com/verify-code?code=1709-4060452b-1b01-4991-9b7e-93e98e139e9d
       |)
       |11 OK Success
-      |""".stripMargin.lines.mkString("\r\n")
+      |""".stripMargin.linesIterator.mkString("\r\n")
 
   val BodyText8BitResponse =
     """* 2077 FETCH (BODY[1] {87}
       |Jestliže se vám newsletter nezobrazil správně, klikněte prosím sem
       |Červen 2017 )
       |12 OK Success
-      |""".stripMargin.lines.mkString("\r\n")
+      |""".stripMargin.linesIterator.mkString("\r\n")
 
   val BodyTextQuotedPrintableResponse =
     """* 4249 FETCH (BODY[1] {745}
@@ -498,7 +498,7 @@ object IMAPClientFetchSpec extends Properties("IMAPClient.Fetch"){
       |">=20
       |)
       |13 OK Success
-      |""".stripMargin.lines.mkString("\r\n")
+      |""".stripMargin.linesIterator.mkString("\r\n")
 
   val BodyTextBase64Response =
     """* 3632 FETCH (BODY[1] {3112}
@@ -548,7 +548,7 @@ object IMAPClientFetchSpec extends Properties("IMAPClient.Fetch"){
       |MDZmZGMwNjliZDQ0OGE2YTI0MTFhZGU2ZGZjMzgzND4gICAgICAgICAgICAgICAgICAg
       |ICAgICAgICAgICAgICAgICAgDQoNCg==)
       |13 OK Success
-    """.stripMargin.lines.mkString("\r\n")
+    """.stripMargin.linesIterator.mkString("\r\n")
 
   val SP = " "
 
@@ -558,13 +558,13 @@ object IMAPClientFetchSpec extends Properties("IMAPClient.Fetch"){
         |
         |Please click on the link below to create your account https://accounts.restcomm.com/verify-code?code=1709-4060452b-1b01-4991-9b7e-93e98e139e9d
         |
-        |""".stripMargin.lines.mkString("\r\n")
+        |""".stripMargin.linesIterator.mkString("\r\n")
   }
 
   property("decode-fetch-bytes.8bit") = forAll(Gen.choose(1, BodyText8BitResponse.size))  { sz =>
     decodeFetchText(BodyText8BitResponse, sz, encoding = "8BIT", charset = Some("UTF-8")) ?=
       """Jestliže se vám newsletter nezobrazil správně, klikněte prosím sem
-        |Červen 2017 """.stripMargin.lines.mkString("\r\n")
+        |Červen 2017 """.stripMargin.linesIterator.mkString("\r\n")
   }
 
 
@@ -580,14 +580,14 @@ object IMAPClientFetchSpec extends Properties("IMAPClient.Fetch"){
          |<body><style type="text/css">div#emailPreHeader{ display: none !important; }</style><div id="emailPreHeader" style="mso-hide:all; visibility:hidden; opacity:0; color:transparent; mso-line-height-rule:exactly; line-height:0; font-size:0px; overflow:hidden; border-width:0; display:none !important;">ReSharper Ult. 2017.3 EAP, GoLand EAP 18, Kotlin/Native IDE Support Preview</div>$SP
          |<div style="background:#ffffff;padding:0px 0px 0px 0px;margin:0px 0px 0px 0px;font-size:14px;font-family:Arial,Helvetica,sans-serif;line-height:24px">$SP
          |
-         |""".stripMargin.lines.mkString("\r\n")
+         |""".stripMargin.linesIterator.mkString("\r\n")
   }
 
 
   property("decode-fetch-bytes.base64.text") = forAll(Gen.choose(1, BodyTextBase64Response.size))  { sz =>
 
     val r = decodeFetchText(BodyTextBase64Response, sz, encoding = "BASE64", charset = Some("UTF-8"))
-      .lines.map(_.trim).mkString("\r\n")
+      .linesIterator.map(_.trim).mkString("\r\n")
 
     val e =
       s"""
@@ -617,7 +617,7 @@ object IMAPClientFetchSpec extends Properties("IMAPClient.Fetch"){
          |
          |To unsubscribe from future emails or to update your email preferences click here <http://app.go.cloudera.com/e/sl?s=1465054361&elq=306fdc069bd448a6a2411ade6dfc3834>
          |
-         |""".stripMargin.lines.mkString("\r\n")
+         |""".stripMargin.linesIterator.mkString("\r\n")
 
 
     r ?= e

--- a/src/test/scala/spinoco/fs2/mail/internal/TakeThroughDrainSpec.scala
+++ b/src/test/scala/spinoco/fs2/mail/internal/TakeThroughDrainSpec.scala
@@ -24,7 +24,7 @@ object TakeThroughDrainSpec extends Properties("TakeThroughDrain"){
     fs2.concurrent.Queue.unbounded[IO, Int].flatMap{ queue =>
 
       (source.through(queue.enqueue).drain ++
-        queue.dequeue.through(internal.takeThroughDrain(_ != 1)).take(2).drain ++
+        Stream.eval(queue.dequeue1).repeat.through(internal.takeThroughDrain(_ != 1)).take(2).drain ++
         Stream.eval(queue.dequeue1)
       ).compile.last
     }.unsafeRunTimed(10.second).flatten ?= Some(3)
@@ -39,7 +39,7 @@ object TakeThroughDrainSpec extends Properties("TakeThroughDrain"){
 
     fs2.concurrent.Queue.unbounded[IO, Int].flatMap{ queue =>
       (source.through(queue.enqueue).drain ++
-        queue.dequeue.through(internal.takeThroughDrain(_ != 1)).drain ++
+        Stream.eval(queue.dequeue1).repeat.through(internal.takeThroughDrain(_ != 1)).drain ++
         Stream.eval(queue.dequeue1)
         ).compile.last
     }.unsafeRunTimed(10.second).flatten ?= Some(3)

--- a/src/test/scala/spinoco/fs2/mail/smtp/MIMEEncodeMultipartSpec.scala
+++ b/src/test/scala/spinoco/fs2/mail/smtp/MIMEEncodeMultipartSpec.scala
@@ -30,7 +30,7 @@ object MIMEEncodeMultipartSpec extends Properties("MIMEEncodeMultipart") {
       |. Dot starting line
       |--- end
       |
-      |""".stripMargin.lines.mkString("\r\n")
+      |""".stripMargin.linesIterator.mkString("\r\n")
   ))
 
    val htmlText = Stream.chunk(StringChunk(
@@ -40,7 +40,7 @@ object MIMEEncodeMultipartSpec extends Properties("MIMEEncodeMultipart") {
        |    <div>This contains international chars ěščřžý </div>
        |  </body>
        |</html>
-       |""".stripMargin.lines.mkString("\r\n")
+       |""".stripMargin.linesIterator.mkString("\r\n")
    ))
 
   property("alternative") = protect {
@@ -99,7 +99,7 @@ object MIMEEncodeMultipartSpec extends Properties("MIMEEncodeMultipart") {
       |
       |------boundary-----
       |
-      |""".stripMargin.lines.mkString("\r\n")
+      |""".stripMargin.linesIterator.mkString("\r\n")
 
 
   }
@@ -205,7 +205,7 @@ object MIMEEncodeMultipartSpec extends Properties("MIMEEncodeMultipart") {
         |
         |-----mixed-boundary-----
         |
-        |""".stripMargin.lines.mkString("\r\n")
+        |""".stripMargin.linesIterator.mkString("\r\n")
   }
 
 }

--- a/src/test/scala/spinoco/fs2/mail/smtp/MIMEEncodePlaintextSpec.scala
+++ b/src/test/scala/spinoco/fs2/mail/smtp/MIMEEncodePlaintextSpec.scala
@@ -27,7 +27,7 @@ object MIMEEncodePlaintextSpec extends Properties("MIMEEncodePlaintext") {
       |. Dot starting line
       |--- end
       |
-      """.stripMargin.lines.mkString("\r\n")
+      """.stripMargin.linesIterator.mkString("\r\n")
   )).covary[IO]
 
   property("defaults") = protect {
@@ -64,7 +64,7 @@ object MIMEEncodePlaintextSpec extends Properties("MIMEEncodePlaintext") {
         |. Dot starting line
         |--- end
         |
-      """.stripMargin.lines.mkString("\r\n")
+      """.stripMargin.linesIterator.mkString("\r\n")
 
   }
 
@@ -103,7 +103,7 @@ object MIMEEncodePlaintextSpec extends Properties("MIMEEncodePlaintext") {
         |. Dot starting line
         |--- end
         |
-      """.stripMargin.lines.mkString("\r\n")
+      """.stripMargin.linesIterator.mkString("\r\n")
   }
 
   property("specified.transfer-encoding") = protect {
@@ -139,7 +139,7 @@ object MIMEEncodePlaintextSpec extends Properties("MIMEEncodePlaintext") {
       |  aGF0IHNoYWxsIGJlIGVuY29kZWQNCi4gRG90IHN0YXJ0aW5nIGxpbmUNCi0tLSBlbmQNCg0KI
       |  CAgICAg
       |
-      |""".stripMargin.lines.mkString("\r\n")
+      |""".stripMargin.linesIterator.mkString("\r\n")
   }
 
 }

--- a/src/test/scala/spinoco/fs2/mail/smtp/SMTPClientSpec.scala
+++ b/src/test/scala/spinoco/fs2/mail/smtp/SMTPClientSpec.scala
@@ -20,7 +20,7 @@ object SMTPClientSpec extends Properties("SMTPClient"){
         | .
         |x.
         |......
-      """.stripMargin.lines.mkString("\r\n").getBytes))
+      """.stripMargin.linesIterator.mkString("\r\n").getBytes))
     ).covary[IO]
     .chunkLimit(chunkSize).flatMap(ch => Stream.chunk(ch))
     .through(SMTPClient.impl.insertDotIfNeeded)
@@ -29,14 +29,14 @@ object SMTPClientSpec extends Properties("SMTPClient"){
       ByteVector.view(bs.values, bs.offset, bs.size)
     }
     .compile.toVector
-    .map(_.reduce(_ ++ _).decodeUtf8.right.toOption.getOrElse("").lines.mkString("\r\n"))
+    .map(_.reduce(_ ++ _).decodeUtf8.right.toOption.getOrElse("").linesIterator.mkString("\r\n"))
     .unsafeRunSync() ?=
       """Line
         |..
         | .
         |x.
         |.......
-      """.stripMargin.lines.mkString("\r\n")
+      """.stripMargin.linesIterator.mkString("\r\n")
   }
 
 
@@ -45,7 +45,7 @@ object SMTPClientSpec extends Properties("SMTPClient"){
     Stream.chunk(ByteVectorChunk(ByteVector.view(
       """220 smtp.gmail.com ESMTP k185sm1251101wma.28 - gsmtp
         |
-      """.stripMargin.lines.mkString("\r\n").getBytes
+      """.stripMargin.linesIterator.mkString("\r\n").getBytes
     ))).covary[IO]
     .chunkLimit(chunkSize).flatMap(ch => Stream.chunk(ch))
     .through(SMTPClient.impl.readResponse[IO])
@@ -66,7 +66,7 @@ object SMTPClientSpec extends Properties("SMTPClient"){
         |250-CHUNKING
         |250 SMTPUTF8
         |
-      """.stripMargin.lines.mkString("\r\n").getBytes
+      """.stripMargin.linesIterator.mkString("\r\n").getBytes
     ))).covary[IO]
       .chunkLimit(chunkSize).flatMap(ch => Stream.chunk(ch))
       .through(SMTPClient.impl.readResponse[IO])


### PR DESCRIPTION
As I said in (this PR)[https://github.com/Spinoco/fs2-mail/pull/33] the problem you had could have been related to the tests.

Today I played some more with the example and noticed that `fs2.concurrent.Queue.synchronous[F, A]` can only contain one element at a time (which means that using this data structure for the implementation couldn't make it work).

Using an `unbounded` Queue in the implementation of `internal.takeThroughDrain` solves the issue. I don't know if this changes the intended semantic of the author in some way but we could propose something based on this changes and finally update fs2-mail to fs2 2.0.1!

P.S. I bumped the scala and sbt version only to make metals work. Probably the first two commits in this PR can be dropped.
